### PR TITLE
Fixed name resolution problems caused by a wrong nodehandle

### DIFF
--- a/ros_queue/include/ros_queue/ros_converted_queue.hpp
+++ b/ros_queue/include/ros_queue/ros_converted_queue.hpp
@@ -87,7 +87,7 @@ class ROSConvertedQueue: public DynamicConvertedQueue<typename QueueElementTrait
             }
             else if (!interfaces.arrival_prediction_service_name.empty())
             {
-                arrival_service_client_ = PersistentServiceClient<TPredictionServiceClass>(nh, interfaces.arrival_prediction_service_name);
+                arrival_service_client_ = PersistentServiceClient<TPredictionServiceClass>(nh_, interfaces.arrival_prediction_service_name);
             }
             else
             {
@@ -106,7 +106,7 @@ class ROSConvertedQueue: public DynamicConvertedQueue<typename QueueElementTrait
             }
             else if (!interfaces.transmission_prediction_service_name.empty())
             {
-                transmission_service_client_ = PersistentServiceClient<TPredictionServiceClass>(nh, interfaces.transmission_prediction_service_name);
+                transmission_service_client_ = PersistentServiceClient<TPredictionServiceClass>(nh_, interfaces.transmission_prediction_service_name);
             }
             else
             {

--- a/ros_queue/include/ros_queue/ros_queue.hpp
+++ b/ros_queue/include/ros_queue/ros_queue.hpp
@@ -72,7 +72,7 @@ class ROSQueue: public DynamicQueue<typename QueueElementTrait<TROSMsgType>::Ele
             }
             else if (!interfaces.arrival_prediction_service_name.empty())
             {
-                arrival_service_client_ = PersistentServiceClient<TPredictionServiceClass>(nh, interfaces.arrival_prediction_service_name);
+                arrival_service_client_ = PersistentServiceClient<TPredictionServiceClass>(nh_, interfaces.arrival_prediction_service_name);
             }
             else
             {
@@ -91,7 +91,7 @@ class ROSQueue: public DynamicQueue<typename QueueElementTrait<TROSMsgType>::Ele
             }
             else if (!interfaces.transmission_prediction_service_name.empty())
             {
-                transmission_service_client_ = PersistentServiceClient<TPredictionServiceClass>(nh, interfaces.transmission_prediction_service_name);
+                transmission_service_client_ = PersistentServiceClient<TPredictionServiceClass>(nh_, interfaces.transmission_prediction_service_name);
             }
             else
             {

--- a/ros_queue/include/ros_queue/ros_virtual_queue.hpp
+++ b/ros_queue/include/ros_queue/ros_virtual_queue.hpp
@@ -66,7 +66,7 @@ class ROSVirtualQueue: public TDynamicVirtualQueueType, public ROSQueueCommonInt
             }
             else if (!interfaces.arrival_evaluation_service_name.empty())
             {
-                arrival_evaluation_service_client_ = PersistentServiceClient<ros_queue_msgs::FloatRequest>(nh, interfaces.arrival_evaluation_service_name);
+                arrival_evaluation_service_client_ = PersistentServiceClient<ros_queue_msgs::FloatRequest>(nh_, interfaces.arrival_evaluation_service_name);
             }
             else
             {
@@ -85,7 +85,7 @@ class ROSVirtualQueue: public TDynamicVirtualQueueType, public ROSQueueCommonInt
             }
             else if (!interfaces.departure_evaluation_service_name.empty())
             {
-                departure_evaluation_service_client_ = PersistentServiceClient<ros_queue_msgs::FloatRequest>(nh, interfaces.departure_evaluation_service_name);
+                departure_evaluation_service_client_ = PersistentServiceClient<ros_queue_msgs::FloatRequest>(nh_, interfaces.departure_evaluation_service_name);
             }
             else
             {


### PR DESCRIPTION
The expected name resolution was wrong. It was caused by using a private node handle instead of a normal node handle for creating the persistent services in the ros_queues